### PR TITLE
Do not statically link ps3load with libz

### DIFF
--- a/tools/ps3load/Makefile
+++ b/tools/ps3load/Makefile
@@ -34,11 +34,7 @@ endif
 
 ifneq (,$(findstring MINGW,$(UNAME)))
 	EXEEXT		:= .exe
-	PLATFORM_LIBS	:=	-static -lws2_32
-endif
-
-ifneq (,$(findstring Linux,$(shell uname -s)))
-	LDFLAGS += -static
+	PLATFORM_LIBS	:=	-lws2_32
 endif
 
 ifneq (,$(findstring Darwin,$(shell uname -s)))


### PR DESCRIPTION
This makes no sense, there's no reason to statically link it. Also considering
that this is a host executable, and most linux systems only come
with libz.so and no libz.a which makes psl1ght not compilable.
