### PR TITLE
fixes "expected declaration specifiers or '...' before 'size_t'" errors in many places.

### DIFF
--- a/ppu/include/ppu-types.h
+++ b/ppu/include/ppu-types.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 	extern "C" {


### PR DESCRIPTION
fixes "expected declaration specifiers or '...' before 'size_t'" errors in many places.

Very minor change, but needed since many functions use 'size_t'.
