### PR TITLE
Adding basic macros for pointer/u32 conversion

### DIFF
--- a/ppu/include/prx-macros.h
+++ b/ppu/include/prx-macros.h
@@ -1,0 +1,11 @@
+#ifndef __PRX_MACROS_H__
+#define __PRX_MACROS_H__
+
+#include <ppu-types.h>
+
+#define PTR(x) ((u32) ((u64) x))
+#define CHAR_PTR(x) ((char *) ((u64) x))
+#define VOID_PTR(x) ((void *) ((u64) x))
+
+
+#endif /* __PRX_MACROS_H__ */


### PR DESCRIPTION
This whole "pointers are 32 bits for prx files" is annoying, I think having macros for easily converting pointers to u32 and u32 to known pointers
