### PR TITLE
Fix overriding of ICON0.PNG

### DIFF
--- a/ppu_rules
+++ b/ppu_rules
@@ -69,7 +69,7 @@ TARGET		?= $(notdir $(CURDIR))
 	@echo building pkg ... $(notdir $@)
 	$(VERB) mkdir -p $(BUILDDIR)/pkg
 	$(VERB) mkdir -p $(BUILDDIR)/pkg/USRDIR
-	$(VERB) cp $(ICON0) $(BUILDDIR)/pkg/
+	$(VERB) cp $(ICON0) $(BUILDDIR)/pkg/ICON0.PNG
 	$(VERB) $(SELF_NPDRM) $(BUILDDIR)/$(basename $(notdir $<)).elf $(BUILDDIR)/pkg/USRDIR/EBOOT.BIN $(CONTENTID) >> /dev/null
 	$(VERB) $(SFO) --title "$(TITLE)" --appid "$(APPID)" -f $(SFOXML) $(BUILDDIR)/pkg/PARAM.SFO
 	$(VERB) if test -n "$(PKGFILES)" -a -d "$(PKGFILES)"; then cp -rf $(PKGFILES)/* $(BUILDDIR)/pkg/; fi

--- a/templates/trivial/Makefile
+++ b/templates/trivial/Makefile
@@ -20,6 +20,11 @@ LDFLAGS=
 # Destination where the .pkg is built
 BUILDDIR=build
 
+# Put your user data into this directory - all will be added to the .pkg
+# add /dev_hdd0/game/$APPID/ to the relative path of the file inside $PKGFILES
+# e.g. $PKGFILES/foo.jpg -> /dev_hdd0/game/MY_APP_ID/foo.jpg
+PKGFILES=data
+
 # If you want to use dependancy checking, define a directory for .d files
 # DEPSDIR=
 
@@ -29,7 +34,7 @@ BUILDDIR=build
 #TITLE=Sample
 
 # Icon that appears in XMB. Needs to be of certain properties.
-#ICON=file.png
+#ICON0=file.png
 
 # ID of your application. Also the installation directory
 # (/dev_hdd0/game/$APPID/)


### PR DESCRIPTION
Minor fix - have ppu_rules change the name of the icon image to ICON0.PNG, which is what is expected.
Also a small fix to the trivial template
