### PR TITLE
Fix librsx when building with GCC 7.2.0

### DIFF
--- a/ppu/librsx/commands.c
+++ b/ppu/librsx/commands.c
@@ -31,7 +31,7 @@ s32 __attribute__((noinline)) rsxContextCallback(gcmContextData *context,u32 cou
 		"mr		2,31\n"
 		"addi	1,1,128\n"
 		: : "b"(context->callback)
-		: "r31", "r0", "r1", "r2", "lr"
+		: "r31", "r0", "lr"
 	);
 	return result;
 }


### PR DESCRIPTION
GCC 7 changed the way it handles register clobber declarations for inline PPC asm:
https://gcc.gnu.org/gcc-7/changes.html

This change makes GCC 7.2.0 emit the same code as GCC 4.7.0, and fixes ScummVM crashing after a few seconds.
The produced code still works when building with GCC 4.7.