### PR TITLE
Adds unlink() function

### DIFF
--- a/ppu/crt/crt1.c
+++ b/ppu/crt/crt1.c
@@ -32,6 +32,7 @@ extern long int __librt_telldir_r(struct _reent *r,DIR *dirp);
 extern void __librt_rewinddir_r(struct _reent *r,DIR *dirp);
 extern void __librt_seekdir_r(struct _reent *r,DIR *dirp,long int loc);
 extern int __librt_rmdir_r(struct _reent *r,const char *dirname);
+extern int __librt_unlink_r(struct _reent *r,const char *path);
 
 extern int __librt_usleep_r(struct _reent *r,useconds_t usec);
 extern unsigned int __librt_sleep_r(struct _reent *r,unsigned int seconds);
@@ -76,6 +77,7 @@ static void __syscalls_init(void)
 	__syscalls.rewinddir_r = __librt_rewinddir_r;
 	__syscalls.seekdir_r = __librt_seekdir_r;
 	__syscalls.rmdir_r = __librt_rmdir_r;
+	__syscalls.unlink_r = __librt_unlink_r;
 
 	__syscalls.sleep_r = __librt_sleep_r;
 	__syscalls.usleep_r = __librt_usleep_r;

--- a/ppu/librt/Makefile
+++ b/ppu/librt/Makefile
@@ -45,7 +45,7 @@ VPATH :=	$(BASEDIR)
 OBJS		:= \
 			sbrk.o exit.o close.o lseek.o read.o open.o sleep.o write.o fstat.o \
 			socket.o lock.o dirent.o mkdir.o times.o umask.o lv2errno.o heap.o \
-			chmod.o rename.o rmdir.o isatty.o gettod.o settod.o
+			chmod.o rename.o rmdir.o isatty.o gettod.o settod.o unlink.o
 
 all: ppu
 

--- a/ppu/librt/unlink.c
+++ b/ppu/librt/unlink.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <_ansi.h>
+#include <_syslist.h>
+#include <sys/reent.h>
+#include <sys/errno.h>
+#include <sys/types.h>
+#include <sys/lv2errno.h>
+
+#include <sys/file.h>
+
+int
+_DEFUN(__librt_unlink_r,(r,path),
+	   struct _reent *r _AND
+	   const char *path)
+{
+	return lv2errno_r(r,sysLv2FsUnlink(path));
+}


### PR DESCRIPTION
following @zeldin feedback on ps3dev/ps3libraries#36  on `rename()`, I realized that function `int unlink(const char *path)` was also missing, so I wanted to add it, and avoid calling sysLv2FsUnlink() directly from my homebrew app.