### PR TITLE
Fix raw2h tool output

### DIFF
--- a/tools/raw2h/raw2h.c
+++ b/tools/raw2h/raw2h.c
@@ -60,6 +60,7 @@ int main(int argc, char **argv)
 			fprintf(fo, "0x%.2x%s ", buf[k] & 0xff, ((k != r - 1) && ((k & 0xf) != 0xf)) ? "," : "");
 		}
 	}
+	fprintf(fo, "\n");
 
 	fclose(fi);
 	fclose(fo);


### PR DESCRIPTION
Currently, when you compile an .S file generated by `raw2h` you'll get a warning like:
```
lib/spu_soundmodule.S: Assembler messages:
lib/spu_soundmodule.S:3783: Warning: partial line at end of file ignored
```

This is a small fix to raw2h, adding a `\n` to the end of the .S file, so the last line is not ignored by the compiler.

