### PR TITLE
Don't use fixed buffer size it fails with big executables

### DIFF
--- a/tools/geohot/make_self.c
+++ b/tools/geohot/make_self.c
@@ -78,7 +78,7 @@ AES_KEY aes_key;
 
 u8* input_elf_data;
 
-#define ZLIB_LEVEL 6
+#define ZLIB_LEVEL 9
 
 int def(u8 *source, int source_size, u8 **dest, int* dest_size) {
   int ret;


### PR DESCRIPTION
When creating big SELF, `def_buffer` may not be large enough to get the whole deflated section. Compacted data is then invalid.
Make use of `deflateBound` to allocate a buffer large enough to get the whole deflated stream.