### PR TITLE
Support apple M1 (arm64)

### DIFF
--- a/tools/geohot/Makefile
+++ b/tools/geohot/Makefile
@@ -40,6 +40,12 @@ ifneq (,$(findstring Darwin,$(UNAME)))
 	CXXFLAGS	+=	-fvisibility=hidden
 	CFLAGS	+= -I/usr/local/include -I/usr/local/opt/libelf/include/libelf -I/usr/local/opt/openssl/include
 	LDFLAGS		+= -mmacosx-version-min=$(OSX_MIN) -Wl,-syslibroot,$(SDK) -L/opt/local/lib -L/usr/local/opt/openssl/lib -lgmp -lcrypto -lz
+
+  ifneq (,$(findstring arm,$(shell uname -p)))
+	CFLAGS	    += -I/opt/homebrew/include -I/opt/homebrew/opt/libelf/include/libelf -I/opt/homebrew/opt/openssl/include
+	LDFLAGS		+= -L/opt/homebrew/lib -L/opt/homebrew/opt/openssl/lib
+  endif
+
 endif
 
 ifneq (,$(findstring BSD,$(UNAME)))

--- a/tools/sprxlinker/Makefile
+++ b/tools/sprxlinker/Makefile
@@ -31,8 +31,9 @@ ifneq (,$(findstring CYGWIN,$(UNAME)))
 endif
 
 ifneq (,$(findstring Darwin,$(UNAME)))
-	CFLAGS	+= -I/opt/local/include -I/usr/local/opt/libelf/include/libelf
-	LDFLAGS	+= -L/opt/local/lib -lelf
+	CFLAGS	+= -I/opt/local/include -I/usr/local/opt/libelf/include/libelf \
+	           -I/opt/homebrew/include -I/opt/homebrew/opt/libelf/include/libelf
+	LDFLAGS	+= -L/opt/local/lib -L/opt/homebrew/lib -lelf
 	OS		:= Mac
 endif
 


### PR DESCRIPTION
This PR adds library paths to build the tools on macOS w/ Apple M1 processors.

Note: Homebrew package manager install libs on `/opt/homebrew/` when running on Apple M1 (arm64)