### PR TITLE
Make the project packageable with DESTDIR variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ doc:
 	@doxygen doxygen.conf
 
 install-ctrl:
-	@[ -d $(PSL1GHT) ] || mkdir -p $(PSL1GHT)
-	@cp -frv base_rules $(PSL1GHT)
-	@cp -frv ppu_rules  $(PSL1GHT)
-	@cp -frv spu_rules  $(PSL1GHT)
-	@cp -frv data_rules $(PSL1GHT)
+	@[ -d $(DESTDIR)$(PSL1GHT) ] || mkdir -p $(DESTDIR)$(PSL1GHT)
+	@cp -frv base_rules $(DESTDIR)$(PSL1GHT)
+	@cp -frv ppu_rules  $(DESTDIR)$(PSL1GHT)
+	@cp -frv spu_rules  $(DESTDIR)$(PSL1GHT)
+	@cp -frv data_rules $(DESTDIR)$(PSL1GHT)
 
 install-socat:
 	@$(MAKE) -C tools install-socat --no-print-directory

--- a/common/libsimdmath/ppu/Makefile
+++ b/common/libsimdmath/ppu/Makefile
@@ -63,14 +63,14 @@ ppu:
 #---------------------------------------------------------------------------------
 install-header:
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/include/simdmath ] || mkdir -p $(PSL1GHT)/ppu/include/simdmath
-	@cp -frv $(CURDIR)/../common/simdmath.h $(PSL1GHT)/ppu/include/simdmath
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/include/simdmath ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/include/simdmath
+	@cp -frv $(CURDIR)/../common/simdmath.h $(DESTDIR)$(PSL1GHT)/ppu/include/simdmath
 
 #---------------------------------------------------------------------------------
 install: all install-header
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: $(OBJS)

--- a/common/libsimdmath/spu/Makefile
+++ b/common/libsimdmath/spu/Makefile
@@ -72,14 +72,14 @@ spu:
 #---------------------------------------------------------------------------------
 install-header:
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/spu/include/simdmath ] || mkdir -p $(PSL1GHT)/spu/include/simdmath
-	@cp -frv $(CURDIR)/../common/simdmath.h $(PSL1GHT)/spu/include/simdmath
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu/include/simdmath ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu/include/simdmath
+	@cp -frv $(CURDIR)/../common/simdmath.h $(DESTDIR)$(PSL1GHT)/spu/include/simdmath
 
 #---------------------------------------------------------------------------------
 install: all install-header
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/spu/lib ] || mkdir -p $(PSL1GHT)/spu/lib
-	@cp -frv $(CURDIR)/lib/spu/*.a $(PSL1GHT)/spu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu/lib
+	@cp -frv $(CURDIR)/lib/spu/*.a $(DESTDIR)$(PSL1GHT)/spu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: $(OBJS)

--- a/common/libspumars/ppu/Makefile
+++ b/common/libspumars/ppu/Makefile
@@ -80,15 +80,15 @@ ppu:
 #---------------------------------------------------------------------------------
 install-header:
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/include ] || mkdir -p $(PSL1GHT)/ppu/include
-	@cp -frv $(CURDIR)/../include/common/mars $(PSL1GHT)/ppu/include
-	@cp -frv $(CURDIR)/../include/ppu/mars $(PSL1GHT)/ppu/include
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/include ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/include
+	@cp -frv $(CURDIR)/../include/common/mars $(DESTDIR)$(PSL1GHT)/ppu/include
+	@cp -frv $(CURDIR)/../include/ppu/mars $(DESTDIR)$(PSL1GHT)/ppu/include
 
 #---------------------------------------------------------------------------------
 install: all install-header
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 DEPENDS	:=	$(OBJSBASE:.o=.d) \

--- a/common/libspumars/spu/Makefile
+++ b/common/libspumars/spu/Makefile
@@ -87,15 +87,15 @@ spu:
 #---------------------------------------------------------------------------------
 install-header:
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/spu/include ] || mkdir -p $(PSL1GHT)/spu/include
-	@cp -frv $(CURDIR)/../include/common/mars $(PSL1GHT)/spu/include
-	@cp -frv $(CURDIR)/../include/spu/mars $(PSL1GHT)/spu/include
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu/include ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu/include
+	@cp -frv $(CURDIR)/../include/common/mars $(DESTDIR)$(PSL1GHT)/spu/include
+	@cp -frv $(CURDIR)/../include/spu/mars $(DESTDIR)$(PSL1GHT)/spu/include
 
 #---------------------------------------------------------------------------------
 install: all install-header
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/spu/lib ] || mkdir -p $(PSL1GHT)/spu/lib
-	@cp -frv $(CURDIR)/lib/spu/*.a $(PSL1GHT)/spu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu/lib
+	@cp -frv $(CURDIR)/lib/spu/*.a $(DESTDIR)$(PSL1GHT)/spu/lib
 
 #---------------------------------------------------------------------------------
 DEPENDS	:=	$(OBJS_KERNEL:.o=.d) $(OBJS_LIB_BASE:.o=.d) \

--- a/common/vectormath/ppu/Makefile
+++ b/common/vectormath/ppu/Makefile
@@ -7,9 +7,9 @@
 all:
 
 install:
-	@[ -d $(PSL1GHT)/ppu/include/vectormath ] || mkdir -p $(PSL1GHT)/ppu/include/vectormath
-	@cp -frv $(CURDIR)/c $(PSL1GHT)/ppu/include/vectormath
-	@cp -frv $(CURDIR)/cpp $(PSL1GHT)/ppu/include/vectormath
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/include/vectormath ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/include/vectormath
+	@cp -frv $(CURDIR)/c $(DESTDIR)$(PSL1GHT)/ppu/include/vectormath
+	@cp -frv $(CURDIR)/cpp $(DESTDIR)$(PSL1GHT)/ppu/include/vectormath
 
 clean:
 

--- a/common/vectormath/spu/Makefile
+++ b/common/vectormath/spu/Makefile
@@ -7,9 +7,9 @@
 all:
 
 install:
-	@[ -d $(PSL1GHT)/spu/include/vectormath ] || mkdir -p $(PSL1GHT)/spu/include/vectormath
-	@cp -frv $(CURDIR)/c $(PSL1GHT)/spu/include/vectormath
-	@cp -frv $(CURDIR)/cpp $(PSL1GHT)/spu/include/vectormath
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu/include/vectormath ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu/include/vectormath
+	@cp -frv $(CURDIR)/c $(DESTDIR)$(PSL1GHT)/spu/include/vectormath
+	@cp -frv $(CURDIR)/cpp $(DESTDIR)$(PSL1GHT)/spu/include/vectormath
 
 clean:
 

--- a/ppu/Makefile
+++ b/ppu/Makefile
@@ -11,8 +11,8 @@ all:
 	@$(MAKE) -C librsx --no-print-directory
 
 install-headers:
-	@[ -d $(PSL1GHT)/ppu ] || mkdir -p $(PSL1GHT)/ppu
-	@cp -frv include $(PSL1GHT)/ppu
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu
+	@cp -frv include $(DESTDIR)$(PSL1GHT)/ppu
 
 install: install-headers
 	@$(MAKE) -C crt install --no-print-directory

--- a/ppu/crt/Makefile
+++ b/ppu/crt/Makefile
@@ -60,8 +60,9 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@cp -frv $(CURDIR)/ppu/lv2-*.o $(PS3DEV)/ppu/ppu/lib
-	@cp -frv $(CURDIR)/lv2.ld $(PS3DEV)/ppu/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/ppu/lib
+	@cp -frv $(CURDIR)/ppu/lv2-*.o $(DESTDIR)$(PS3DEV)/ppu/ppu/lib
+	@cp -frv $(CURDIR)/lv2.ld $(DESTDIR)$(PS3DEV)/ppu/ppu/lib
 
 .PHONY: crts ppu install
 

--- a/ppu/librsx/Makefile
+++ b/ppu/librsx/Makefile
@@ -60,8 +60,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: $(OBJS)

--- a/ppu/librt/Makefile
+++ b/ppu/librt/Makefile
@@ -61,8 +61,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: $(OBJS)

--- a/ppu/sprx/libaudio/Makefile
+++ b/ppu/sprx/libaudio/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libcamera/Makefile
+++ b/ppu/sprx/libcamera/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libfont/Makefile
+++ b/ppu/sprx/libfont/Makefile
@@ -71,8 +71,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o font_wrapper.o

--- a/ppu/sprx/libfontFT/Makefile
+++ b/ppu/sprx/libfontFT/Makefile
@@ -71,8 +71,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o fontft_wrapper.o

--- a/ppu/sprx/libgcm_sys/Makefile
+++ b/ppu/sprx/libgcm_sys/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o gcm_wrapper.o

--- a/ppu/sprx/libgem/Makefile
+++ b/ppu/sprx/libgem/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libhttp/Makefile
+++ b/ppu/sprx/libhttp/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o http_wrapper.o https_wrapper.o

--- a/ppu/sprx/libhttputil/Makefile
+++ b/ppu/sprx/libhttputil/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libio/Makefile
+++ b/ppu/sprx/libio/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libjpgdec/Makefile
+++ b/ppu/sprx/libjpgdec/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o jpgdec.o

--- a/ppu/sprx/liblv2/Makefile
+++ b/ppu/sprx/liblv2/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o thread_wrapper.o spu_printf_wrapper.o process_wrapper.o \

--- a/ppu/sprx/liblv2dbg/Makefile
+++ b/ppu/sprx/liblv2dbg/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libnet/Makefile
+++ b/ppu/sprx/libnet/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o init.o socket.o

--- a/ppu/sprx/libnetctl/Makefile
+++ b/ppu/sprx/libnetctl/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libpngdec/Makefile
+++ b/ppu/sprx/libpngdec/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o pngdec.o

--- a/ppu/sprx/libresc/Makefile
+++ b/ppu/sprx/libresc/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o resc_wrapper.o

--- a/ppu/sprx/libspurs/Makefile
+++ b/ppu/sprx/libspurs/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o spurs_wrapper.o

--- a/ppu/sprx/libssl/Makefile
+++ b/ppu/sprx/libssl/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libsysfs/Makefile
+++ b/ppu/sprx/libsysfs/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o sysfs_wrapper.o

--- a/ppu/sprx/libsysmodule/Makefile
+++ b/ppu/sprx/libsysmodule/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/ppu/sprx/libsysutil/Makefile
+++ b/ppu/sprx/libsysutil/Makefile
@@ -73,8 +73,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o sysutil_wrapper.o

--- a/ppu/sprx/libusb/Makefile
+++ b/ppu/sprx/libusb/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o usb_wrapper.o

--- a/ppu/sprx/libvdec/Makefile
+++ b/ppu/sprx/libvdec/Makefile
@@ -72,8 +72,8 @@ ppu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/ppu/lib ] || mkdir -p $(PSL1GHT)/ppu/lib
-	@cp -frv $(CURDIR)/lib/ppu/*.a $(PSL1GHT)/ppu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/ppu/lib [ -d $(DESTDIR)$(PSL1GHT)/ppu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/ppu/lib
+	@cp -frv $(CURDIR)/lib/ppu/*.a $(DESTDIR)$(PSL1GHT)/ppu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: sprx.o

--- a/spu/Makefile
+++ b/spu/Makefile
@@ -10,8 +10,8 @@ all:
 	@$(MAKE) -C libspuatomic --no-print-directory
 
 install-headers:
-	@[ -d $(PSL1GHT)/spu ] || mkdir -p $(PSL1GHT)/spu
-	@cp -frv include $(PSL1GHT)/spu
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu
+	@cp -frv include $(DESTDIR)$(PSL1GHT)/spu
 
 install: install-headers
 	@$(MAKE) -C libsputhread install --no-print-directory

--- a/spu/libspuatomic/Makefile
+++ b/spu/libspuatomic/Makefile
@@ -58,8 +58,8 @@ spu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/spu/lib ] || mkdir -p $(PSL1GHT)/spu/lib
-	@cp -frv $(CURDIR)/lib/spu/*.a $(PSL1GHT)/spu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu/lib [ -d $(DESTDIR)$(PSL1GHT)/spu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu/lib
+	@cp -frv $(CURDIR)/lib/spu/*.a $(DESTDIR)$(PSL1GHT)/spu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: $(OBJS)

--- a/spu/libspudma/Makefile
+++ b/spu/libspudma/Makefile
@@ -58,8 +58,8 @@ spu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/spu/lib ] || mkdir -p $(PSL1GHT)/spu/lib
-	@cp -frv $(CURDIR)/lib/spu/*.a $(PSL1GHT)/spu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu/lib [ -d $(DESTDIR)$(PSL1GHT)/spu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu/lib
+	@cp -frv $(CURDIR)/lib/spu/*.a $(DESTDIR)$(PSL1GHT)/spu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: $(OBJS)

--- a/spu/libsputhread/Makefile
+++ b/spu/libsputhread/Makefile
@@ -61,8 +61,8 @@ spu:
 #---------------------------------------------------------------------------------
 install: all
 #---------------------------------------------------------------------------------
-	@[ -d $(PSL1GHT)/spu/lib ] || mkdir -p $(PSL1GHT)/spu/lib
-	@cp -frv $(CURDIR)/lib/spu/*.a $(PSL1GHT)/spu/lib
+	@[ -d $(DESTDIR)$(PSL1GHT)/spu/lib [ -d $(DESTDIR)$(PSL1GHT)/spu/lib ] || mkdir -p $(DESTDIR)$(PSL1GHT)/spu/lib
+	@cp -frv $(CURDIR)/lib/spu/*.a $(DESTDIR)$(PSL1GHT)/spu/lib
 
 #---------------------------------------------------------------------------------
 $(LIBRARY).a: $(OBJS)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -31,8 +31,8 @@ all:
 	@$(MAKE) -C fself --no-print-directory
 
 install-socat:
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
-	@cp -frv $(CURDIR)/socat/$(host)/* $(PS3DEV)/bin
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
+	@cp -frv $(CURDIR)/socat/$(host)/* $(DESTDIR)$(PS3DEV)/bin
 
 install:
 	@$(MAKE) -C geohot install --no-print-directory

--- a/tools/cgcomp/Makefile
+++ b/tools/cgcomp/Makefile
@@ -132,8 +132,8 @@ clean:
 
 install: $(BUILD)
 	@echo Installing $(TARGET)$(EXEEXT)
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
-	@install -m 755  $(OUTPUT) $(PS3DEV)/bin
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
+	@install -m 755  $(OUTPUT) $(DESTDIR)$(PS3DEV)/bin
 	@$(CGTOOLKIT)
 #---------------------------------------------------------------------------------
 else

--- a/tools/fself/Makefile
+++ b/tools/fself/Makefile
@@ -139,8 +139,8 @@ clean:
 #---------------------------------------------------------------------------------
 install: $(BUILD)
 	@echo Installing $(TARGET)$(EXEEXT)
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
-	@install -m 755 $(OUTPUT) $(PS3DEV)/bin
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
+	@install -m 755 $(OUTPUT) $(DESTDIR)$(PS3DEV)/bin
 
 #---------------------------------------------------------------------------------
 run:

--- a/tools/generic/Makefile
+++ b/tools/generic/Makefile
@@ -51,5 +51,5 @@ clean:
 
 install: all
 	@echo Installing $(TARGETS)
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
-	@install -m 755 $(TARGETS) $(PS3DEV)/bin
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
+	@install -m 755 $(TARGETS) $(DESTDIR)$(PS3DEV)/bin

--- a/tools/geohot/Makefile
+++ b/tools/geohot/Makefile
@@ -75,8 +75,8 @@ package_finalize$(POSTFIX): package_finalize.c
 
 install: $(TARGETS)
 	@echo Installing $(TARGETS)
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
-	@install -m 755 $(TARGETS) $(PS3DEV)/bin
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
+	@install -m 755 $(TARGETS) $(DESTDIR)$(PS3DEV)/bin
 
 clean:
 	@echo clean ...

--- a/tools/ps3load/Makefile
+++ b/tools/ps3load/Makefile
@@ -119,8 +119,8 @@ clean:
 #---------------------------------------------------------------------------------
 install: $(BUILD)
 	@echo Installing $(TARGET)$(EXEEXT)
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
-	@install -m 755 $(OUTPUT) $(PS3DEV)/bin
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
+	@install -m 755 $(OUTPUT) $(DESTDIR)$(PS3DEV)/bin
 
 #---------------------------------------------------------------------------------
 run:

--- a/tools/ps3py/Makefile
+++ b/tools/ps3py/Makefile
@@ -25,7 +25,7 @@ clean:
 	@rm -rf build pkgcrypt.*
 
 install: all
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
 	@echo Installing ICON0.PNG sfo.xml pkgcrypt.* fself.py Struct.py sfo.py pkg.py
-	@install -m 644 ICON0.PNG sfo.xml pkgcrypt.* $(PS3DEV)/bin
-	@./install-scripts $(PS3DEV)/bin/ fself.py Struct.py sfo.py pkg.py
+	@install -m 644 ICON0.PNG sfo.xml pkgcrypt.* $(DESTDIR)$(PS3DEV)/bin
+	@./install-scripts $(DESTDIR)$(PS3DEV)/bin/ fself.py Struct.py sfo.py pkg.py

--- a/tools/raw2h/Makefile
+++ b/tools/raw2h/Makefile
@@ -24,8 +24,8 @@ clean:
 
 install: all
 	@echo Installing $(TARGET)
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
-	@cp $(TARGET) $(PS3DEV)/bin/
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
+	@cp $(TARGET) $(DESTDIR)$(PS3DEV)/bin/
 
 $(TARGET): $(CFILES)
 	@$(CC) $(CFLAGS) $< -o $@

--- a/tools/sprxlinker/Makefile
+++ b/tools/sprxlinker/Makefile
@@ -62,8 +62,8 @@ all: $(TARGET)
 
 install: all
 	@echo Installing $(TARGET)
-	@[ -d $(PS3DEV)/bin ] || mkdir -p $(PS3DEV)/bin
-	@install -m 755 $(TARGET) $(PS3DEV)/bin
+	@[ -d $(DESTDIR)$(PS3DEV)/bin ] || mkdir -p $(DESTDIR)$(PS3DEV)/bin
+	@install -m 755 $(TARGET) $(DESTDIR)$(PS3DEV)/bin
 
 clean:
 	@echo clean ...


### PR DESCRIPTION
For packaging with e.g.
`$ make DESTDIR="${pkgdir}" install`
as done here:
https://aur.archlinux.org/packages/ps3-psl1ght-rules
https://aur.archlinux.org/packages/ps3-psl1ght

Practically any Makefile out there supports this.

On a side note: I updated the ps3toolchain to gcc 9.5.0 (PPU/SPU) and binutils 2.40 (PPU) there.
Feel free to update the toolchain with my updated patches.