### PR TITLE
Add python3 to ps3py build

### DIFF
--- a/tools/ps3py/Makefile
+++ b/tools/ps3py/Makefile
@@ -17,7 +17,7 @@ endif
 all: pkgcrypt.so
 
 pkgcrypt.so: crypt.c setup.py
-	@`./find-python2` setup.py build_ext $(COMPILER)
+	@`./find-python` setup.py build_ext $(COMPILER)
 	@cp build/lib.*/pkgcrypt.* .
 
 clean:

--- a/tools/ps3py/find-python
+++ b/tools/ps3py/find-python
@@ -1,5 +1,5 @@
 #! /bin/sh
-for python in python2.7 python2.6 python2 python; do
+for python in python3 python2.7 python2.6 python2 python; do
   which "$python" >/dev/null 2>&1 && break
 done
 echo "$python"

--- a/tools/ps3py/install-scripts
+++ b/tools/ps3py/install-scripts
@@ -1,7 +1,7 @@
 #! /bin/sh
 target="$1"
 shift
-find_python=`dirname "$0"`/find-python2
+find_python=`dirname "$0"`/find-python
 python=`"$find_python"`
 for file; do
   basefile=`basename "$file"`


### PR DESCRIPTION
Not to long ago, support for Python 3 were added. This pull request adds python3 to list of possible python names in find-python (renamed from find-python2) script. It allows to build ps3py and thus a whole project without python2 installation or aliasing python to python3.

Also, in 3 days from now on, Python 3.12 about to release. And as they say distutils (package for building modules) will be removed. setuptools must be drop in replacement for it. Let me know if ok of me making PR for it too.