### PR TITLE
Fix outdated bool def

### DIFF
--- a/tools/ps3load/source/main.c
+++ b/tools/ps3load/source/main.c
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -64,9 +65,6 @@ typedef signed char s8;
 typedef signed short s16;
 typedef signed int s32;
 typedef signed long long s64;
-
-typedef enum { false, true } bool;
-
 
 static const char *envvar = "PS3LOAD";
 


### PR DESCRIPTION
Toolchain broke on WSL Ubuntu due to a manual definition of `bool`.

This is deprecated behaviour - stdbool includes `bool` already. Making this change allowed the toolchain to build.